### PR TITLE
Reconfigured samples to use env vars for Dapr port instead of hardcoded ports

### DIFF
--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -27,7 +27,7 @@ cd samples/1.hello-world
 In the `app.js` you'll find a simple `express` application, which exposes a few routes and handlers. First, let's take a look at the `stateUrl` at the top of the file: 
 
 ```js
-const stateUrl = `http://localhost:${process.env.DAPR_HTTP_PORT}/v1.0/state`;
+const stateUrl = `http://localhost:${daprPort}/v1.0/state`;
 ```
 When we use the Dapr CLI, it creates an environment variable for the Dapr port, which defaults to 3500. We'll be using this in step 3 when we POST messages to to our system.
 
@@ -105,7 +105,7 @@ You're up and running! Both Dapr and your app logs will appear here.
 
 ## Step 4 - Post Messages to your Service
 
-Now that Dapr and our Node.js app are running, let's POST messages against it.
+Now that Dapr and our Node.js app are running, let's POST messages against it. **Note**: here we're POSTing against port 3500 - if you used a different port, be sure to update your URL accordingly.
 
 You can do this using `curl` with:
 
@@ -125,7 +125,7 @@ In your terminal window, you should see logs indicating that the message was rec
 
 ## Step 5 - Confirm Successful Persistence
 
-Now, let's just make sure that our order was successfully persisted to our state store. Create a GET request against: `http://localhost:3500/v1.0/invoke/mynode/method/order`
+Now, let's just make sure that our order was successfully persisted to our state store. Create a GET request against: `http://localhost:3500/v1.0/invoke/mynode/method/order`. **Note**: Again, be sure to reflect the right port if you chose a port other than 3500.
 
 ```sh
 curl http://localhost:3500/v1.0/invoke/mynode/method/order

--- a/1.hello-world/app.js
+++ b/1.hello-world/app.js
@@ -10,7 +10,8 @@ require('isomorphic-fetch');
 const app = express();
 app.use(bodyParser.json());
 
-const stateUrl = `http://localhost:${process.env.DAPR_HTTP_PORT}/v1.0/state`;
+const daprPort = process.env.DAPR_HTTP_PORT || 3500;
+const stateUrl = `http://localhost:${daprPort}/v1.0/state`;
 const port = 3000;
 
 app.get('/order', (_req, res) => {

--- a/2.hello-kubernetes/README.md
+++ b/2.hello-kubernetes/README.md
@@ -126,7 +126,7 @@ export NODE_APP=$(kubectl get svc nodeapp --output 'jsonpath={.status.loadBalanc
 ## Step 5 - Deploy the Python App with the Dapr Sidecar
 Next, let's take a quick look at our python app. Navigate to the python app in the kubernetes sample: `cd samples/2.hello-kubernetes/python/app.py`.
 
-At a quick glance, this is a basic python app that posts JSON messages to our Dapr URL. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/invoke/nodeapp/method/neworder`. Our message contains some `data` with an orderId that increments once per second:
+At a quick glance, this is a basic python app that posts JSON messages to `localhost:3500`, which is the default listening port for Dapr. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/invoke/nodeapp/method/neworder`. Our message contains some `data` with an orderId that increments once per second:
 
 ```python
 n = 0

--- a/2.hello-kubernetes/README.md
+++ b/2.hello-kubernetes/README.md
@@ -126,10 +126,9 @@ export NODE_APP=$(kubectl get svc nodeapp --output 'jsonpath={.status.loadBalanc
 ## Step 5 - Deploy the Python App with the Dapr Sidecar
 Next, let's take a quick look at our python app. Navigate to the python app in the kubernetes sample: `cd samples/2.hello-kubernetes/python/app.py`.
 
-At a quick glance, this is a basic python app that posts JSON messages to ```localhost:3500```, which is the default listening port for Dapr. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/invoke/nodeapp/method/neworder`. Our message contains some `data` with an orderId that increments once per second:
+At a quick glance, this is a basic python app that posts JSON messages to our Dapr URL. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/invoke/nodeapp/method/neworder`. Our message contains some `data` with an orderId that increments once per second:
 
 ```python
-dapr_url = "http://localhost:3500/v1.0/invoke/nodeapp/method/neworder"
 n = 0
 while True:
     n += 1

--- a/2.hello-kubernetes/node/app.js
+++ b/2.hello-kubernetes/node/app.js
@@ -10,7 +10,8 @@ require('isomorphic-fetch');
 const app = express();
 app.use(bodyParser.json());
 
-const daprUrl = `http://localhost:3500/v1.0`;
+const daprPort = process.env.DAPR_HTTP_PORT || 3500;
+const daprUrl = `http://localhost:${daprPort}/v1.0`;
 const port = 3000;
 
 app.get('/order', (_req, res) => {

--- a/2.hello-kubernetes/python/app.py
+++ b/2.hello-kubernetes/python/app.py
@@ -7,7 +7,9 @@ import time
 import requests
 import os
 
-dapr_url = "http://localhost:3500/v1.0/invoke/nodeapp/method/neworder"
+dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
+dapr_url = "http://localhost:{}/v1.0/invoke/nodeapp/method/neworder".format(dapr_port)
+
 n = 0
 while True:
     n += 1

--- a/3.distributed-calculator/README.md
+++ b/3.distributed-calculator/README.md
@@ -137,7 +137,7 @@ Microservice applications are dynamic with scaling, updates and failures causing
 
 ### Simplified State Management
 
-Dapr side-cars provide state management. In this sample, we persist our calculator's state each time we click a new button. This means we can refresh the page, close the page or even take down our `calculator-front-end` pod, and still retain the same state when we next open it. Dapr adds a layer of indirection so that our app doesn't need to know where it's persisting state. It doesn't have to keep track of keys, handle retry logic or worry about state provider specific configuration. All it has to do is GET or POST against its Dapr sidecar's state endpoint.
+Dapr side-cars provide state management. In this sample, we persist our calculator's state each time we click a new button. This means we can refresh the page, close the page or even take down our `calculator-front-end` pod, and still retain the same state when we next open it. Dapr adds a layer of indirection so that our app doesn't need to know where it's persisting state. It doesn't have to keep track of keys, handle retry logic or worry about state provider specific configuration. All it has to do is GET or POST against its Dapr sidecar's state endpoint: `http://localhost:3500/v1.0/state`.
 
 Take a look at `server.js` in the `react-calculator` directory. Note that it exposes two state endpoints for our React client to get and set state: the GET `/state` endpoint and the POST `/persist` endpoint. Both forward client calls to the Dapr state endpoint: 
 

--- a/3.distributed-calculator/README.md
+++ b/3.distributed-calculator/README.md
@@ -119,7 +119,7 @@ When our front-end server calls the respective operation services (see `server.j
 
 The code below shows calls to the “add” and “subtract” services via the Dapr URLs:
 ```js
-const daprUrl = `http://localhost:3500/v1.0/invoke`;
+const daprUrl = `http://localhost:${daprPort}/v1.0/invoke`;
 
 app.post('/calculate/add', async (req, res) => {
   const addUrl = `${daprUrl}/addapp/method/add`;
@@ -137,12 +137,12 @@ Microservice applications are dynamic with scaling, updates and failures causing
 
 ### Simplified State Management
 
-Dapr side-cars provide state management. In this sample, we persist our calculator's state each time we click a new button. This means we can refresh the page, close the page or even take down our `calculator-front-end` pod, and still retain the same state when we next open it. Dapr adds a layer of indirection so that our app doesn't need to know where it's persisting state. It doesn't have to keep track of keys, handle retry logic or worry about state provider specific configuration. All it has to do is GET or POST against its Dapr sidecar's state endpoint: `http://localhost:3500/v1.0/state`.
+Dapr side-cars provide state management. In this sample, we persist our calculator's state each time we click a new button. This means we can refresh the page, close the page or even take down our `calculator-front-end` pod, and still retain the same state when we next open it. Dapr adds a layer of indirection so that our app doesn't need to know where it's persisting state. It doesn't have to keep track of keys, handle retry logic or worry about state provider specific configuration. All it has to do is GET or POST against its Dapr sidecar's state endpoint.
 
 Take a look at `server.js` in the `react-calculator` directory. Note that it exposes two state endpoints for our React client to get and set state: the GET `/state` endpoint and the POST `/persist` endpoint. Both forward client calls to the Dapr state endpoint: 
 
 ```js
-const stateUrl = "http://localhost:3500/v1.0/state";
+const stateUrl = `http://localhost:${daprPort}/v1.0/state`;
 ```
 
 Our client persists state by simply POSTing JSON key-value pairs (see `react-calculator/client/src/component/App.js`): 

--- a/3.distributed-calculator/react-calculator/server.js
+++ b/3.distributed-calculator/react-calculator/server.js
@@ -5,11 +5,13 @@ const request = require('request');
 const app = express();
 
 const port = 8080;
-const daprUrl = "http://localhost:3500/v1.0/invoke";
-const stateUrl = "http://localhost:3500/v1.0/state";
+const daprPort = process.env.DAPR_HTTP_PORT || 3500;
+
+const daprUrl = `http://localhost:${daprPort}/v1.0/invoke`;
+const stateUrl = `http://localhost:${daprPort}/v1.0/state`;
 
 /**
-The following routes forward requests (using pipe) from our React client to our dapr-enabled services. Our Dapr sidecar lives on localhost:3500. We invoke other Dapr enabled services by calling /v1.0/invoke/<DAPR_ID>/method/<SERVICE'S_ROUTE>.
+The following routes forward requests (using pipe) from our React client to our dapr-enabled services. Our Dapr sidecar lives on localhost:<daprPort>. We invoke other Dapr enabled services by calling /v1.0/invoke/<DAPR_ID>/method/<SERVICE'S_ROUTE>.
 */
 
 app.post('/calculate/add', async (req, res) => {

--- a/4.pub-sub/node-subscriber/app.js
+++ b/4.pub-sub/node-subscriber/app.js
@@ -8,7 +8,7 @@ const bodyParser = require('body-parser');
 
 const app = express();
 // Dapr publishes messages with the application/cloudevents+json content-type
-app.use(bodyParser.json({ type: 'application/*+json' }));
+app.use(bodyParser.json({ type: 'application/json' }));
 
 const port = 3000;
 

--- a/4.pub-sub/react-form/server.js
+++ b/4.pub-sub/react-form/server.js
@@ -11,8 +11,9 @@ const bodyParser = require('body-parser');
 const app = express();
 app.use(bodyParser.json());
 
+const daprPort = process.env.DAPR_HTTP_PORT || 3500;
+const daprUrl = `http://localhost:${daprPort}/v1.0`;
 const port = 8080;
-const daprUrl = `http://localhost:${process.env.DAPR_HTTP_PORT || 3500}/v1.0`;
 
 app.post('/publish', (req, res) => {
   console.log("Publishing: ", req.body);

--- a/5.bindings/pythonapp/app.py
+++ b/5.bindings/pythonapp/app.py
@@ -7,9 +7,7 @@ import time
 import requests
 import os
 
-dapr_port = os.getenv("DAPR_HTTP_PORT")
-if dapr_port is None:
-    dapr_port = 3500
+dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
 
 dapr_url = "http://localhost:{}/v1.0/bindings/sample-topic".format(dapr_port)
 n = 0


### PR DESCRIPTION
# Description

I've updated samples to use environment variables for the Dapr port, given that the port is configurable in standalone mode and all samples currently hardcoded it to port 3500.

While testing, I also discovered and fixed a bug in the pub-sub sample where the node subscriber microservice was not correctly parsing the incoming messages.

## Issue reference

This closes issue #19 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Built and tested new sample images
* [x] Extended the documentation

