### PR TITLE
fix order state url

### DIFF
--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -77,7 +77,7 @@ We also expose a GET endpoint, `/order`:
 
 ```js
 app.get('/order', (_req, res) => {
-    fetch(`${daprUrl}/state/order`)
+    fetch(`${stateUrl}/order`)
         .then((response) => {
             return response.json();
         }).then((orders) => {


### PR DESCRIPTION
# Description

fix the state URL in the  GET /orders handler from `daprUrl` (which is not defined in the example, nor in the code) to `stateUrl` (which is consistent with the POST /neworder handler).

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [N/A] Code compiles correctly
* [N/A] Created/updated tests
* [x] Extended the documentation
