### PR TITLE
[5.pubsub] revert change to fix pubsub sample

### DIFF
--- a/4.pub-sub/node-subscriber/app.js
+++ b/4.pub-sub/node-subscriber/app.js
@@ -8,7 +8,7 @@ const bodyParser = require('body-parser');
 
 const app = express();
 // Dapr publishes messages with the application/cloudevents+json content-type
-app.use(bodyParser.json({ type: 'application/json' }));
+app.use(bodyParser.json({ type: 'application/*+json' }));
 
 const port = 3000;
 


### PR DESCRIPTION
# Description

Problem: the [recent change](https://github.com/dapr/samples/commit/b5b493008de475820f7821284d56eaabcc1a3e03#diff-ea51cac8927d29371f76d979b3fd3fa8) accepts only `application/json` content-type so that node app doesn't not get the cloud event request from Dapr runtime.

* Revert change to fix pubsub sample.

## Issue reference

#79 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The sample code compiles correctly
* [x] You've tested new builds of the sample if you changed sample code
* [x] You've updated the sample's README if necessary
