### PR TITLE
[CI] Set default sample registry in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
         run: python ./.github/scripts/get_release_version.py
       - name: Build docker image
         run: |
+          if [ -z "${{ env.SAMPLE_REGISTRY }}" ]; then
+            export SAMPLE_REGISTRY=docker.io/dapriosamples
+            echo "##[set-env name=SAMPLE_REGISTRY;]$SAMPLE_REGISTRY"
+          fi
+  
           SAMPLE_LIST=(2.hello-kubernetes 3.distributed-calculator 4.pub-sub 5.bindings)
 
           for sample in "${SAMPLE_LIST[@]}"; do


### PR DESCRIPTION
# Description

GitHub Actions CI tries to use secrets variable in the forked repo due to the security reason so when user creates a pr from their fork to original repo, CI will fail to get DOCKER_REGISTRY variable from original repo.

This pr will use the default docker registry in this case.

## Issue reference

N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The sample code compiles correctly
* [ ] You've tested new builds of the sample if you changed sample code
* [ ] You've updated the sample's README if necessary
