### PR TITLE
Remove duplicated word "to" in document of "1.hello-world" sample

### DIFF
--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -29,7 +29,7 @@ In the `app.js` you'll find a simple `express` application, which exposes a few 
 ```js
 const stateUrl = `http://localhost:${daprPort}/v1.0/state`;
 ```
-When we use the Dapr CLI, it creates an environment variable for the Dapr port, which defaults to 3500. We'll be using this in step 3 when we POST messages to to our system.
+When we use the Dapr CLI, it creates an environment variable for the Dapr port, which defaults to 3500. We'll be using this in step 3 when we POST messages to our system.
 
 Next, let's take a look at the ```neworder``` handler:
 


### PR DESCRIPTION
# Description

Remove duplicated word "to" in document of "1.hello-world" sample

## Issue reference

#98 

Please reference the issue this PR will close: #98 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The sample code compiles correctly
* [x] You've tested new builds of the sample if you changed sample code
* [x] You've updated the sample's README if necessary
