### PR TITLE
Fix a command option and testclient's filename

### DIFF
--- a/5.bindings/README.md
+++ b/5.bindings/README.md
@@ -205,7 +205,7 @@ dapr-operator-86cddcfcb7-v2zjp          1/1     Running       0          6h6m
 dapr-placement-5d6465f8d5-pz2qt         1/1     Running       0          6h6m
 dapr-sidecar-injector-dc489d7bc-k2h4q   1/1     Running       0          6h6m
 # Get the log from bindings-pythonapp
-$ kubectl logs bindings-pythonapp-644489969b-c8lg5
+$ kubectl logs bindings-pythonapp-644489969b-c8lg5 python
 ...
 {'data': {'orderId': 240}}
 <Response [200]>
@@ -251,7 +251,7 @@ Once you delete all samples apps, delete Kafka in the cluster.
 
 ```bash
 # move to sample root
-kubectl delete -f ./kafka_testclient.yaml
+kubectl delete -f ./k8s_kafka_testclient.yaml
 # clean up kafka cluster
 helm del --purge dapr-kafka
 ```


### PR DESCRIPTION
# Description
Fix an command option of "kubectl logs" when observing the Python app logs
Fix testclient's incorrect filename

## Issue reference

## Checklist

* [x] The sample code compiles correctly
* [x] You've tested new builds of the sample if you changed sample code
* [ ] You've updated the sample's README if necessary
