### PR TITLE
remove duplicate messageType assignment in pub-sub sample MessageForm

### DIFF
--- a/4.pub-sub/react-form/client/src/MessageForm.js
+++ b/4.pub-sub/react-form/client/src/MessageForm.js
@@ -49,7 +49,7 @@ export class MessageForm extends React.Component {
         <form onSubmit={this.handleSubmit}>
         <div className="form-group">
           <label>Select Message Type</label>
-          <select value={this.state.messageType} className="custom-select custom-select-lg mb-3" name="messageType" onChange={this.handleInputChange} value={this.state.messageType}>
+          <select className="custom-select custom-select-lg mb-3" name="messageType" onChange={this.handleInputChange} value={this.state.messageType}>
             <option value="A">A</option>
             <option value="B">B</option>
             <option value="C">C</option>


### PR DESCRIPTION
# Description

The Pub-Sub sample react-form MessageForm component assigns a dropdown selector value twice, once at the beginning of the element and again at the end, causing linting tools to throw an error when building.

## Issue reference

n/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The sample code compiles correctly
* [x] You've tested new builds of the sample if you changed sample code
* [x] You've updated the sample's README if necessary
