### PR TITLE
Updating curl command to include Content-type:application/json

### DIFF
--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -180,7 +180,7 @@ dapr invoke --app-id nodeapp --method neworder --payload '{"data": { "orderId": 
 Now, we can also do this using `curl` with:
 
 ```sh
-curl -XPOST -d @sample.json http://localhost:3500/v1.0/invoke/nodeapp/method/neworder
+curl -XPOST -d @sample.json -H "Content-Type:application/json" http://localhost:3500/v1.0/invoke/nodeapp/method/neworder
 ```
 
 Or, we can also do this using the Visual Studio Code [Rest Client Plugin](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)


### PR DESCRIPTION
On a Ubuntu 18.04 machine the curl command you provide doesn't work since it's missing header data for content-type.

I added the header data for the command in the walkthrough for example 1.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #194 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The sample code compiles correctly
* [ ] You've tested new builds of the sample if you changed sample code
* [ ] You've updated the sample's README if necessary
