### PR TITLE
Add a warning about non-default namespace usage in Hello Kubernetes sample README

### DIFF
--- a/2.hello-kubernetes/README.md
+++ b/2.hello-kubernetes/README.md
@@ -22,6 +22,9 @@ The first thing you need is an RBAC enabled Kubernetes cluster. This could be ru
 
 Once you have a cluster, follow the steps below to deploy Dapr to it. For more details, look [here](https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md#installing-dapr-on-a-kubernetes-cluster)
 
+> Please note, that using the CLI does not support non-default namespaces.  
+> If you need a non-default namespace, Helm has to be used (see below).
+
 ```
 $ dapr init --kubernetes
 ℹ️  Note: this installation is recommended for testing purposes. For production environments, please use Helm


### PR DESCRIPTION
# Description

It adds the warning to README about only default namespace usage in case of  `dapr init --kubernetes` deployment.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #159 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The sample code compiles correctly
* [x] You've tested new builds of the sample if you changed sample code
* [x] You've updated the sample's README if necessary
