### PR TITLE
Modify default Components path

### DIFF
--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -135,7 +135,7 @@ You're up and running! Both Dapr and your app logs will appear here.
 ```
 > **Note**: the `--app-port` (the port the app runs on) is configurable. Our Node app happens to run on port 3000, but we could configure it to run on any other port. Also note that the Dapr `--port` parameter is optional, and if not supplied, a random available port is used.
 
-The `dapr run` command looks for the default components directory which for Linux/MacOS is `$HOME/.dapr/components` and for Windows is `%USERPROFILE%\.dapr\components` which holds yaml definition files for components Dapr will be using at runtime. When running locally, the yaml files which provide default definitions for a local development environment are placed in this default components directory (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
+The `dapr run` command looks for the default components directory which for Linux/MacOS is `$HOME/.dapr/components` and for Windows is `%USERPROFILE%\.dapr\components` which holds yaml definition files for components Dapr will be using at runtime. When running locally, the yaml files which provide default definitions for a local development environment are placed in this default components directory (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/daprrun.md)). Review the `statestore.yaml` file in the `components` directory:
 
 ```yml
 apiVersion: dapr.io/v1alpha1

--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -135,7 +135,7 @@ You're up and running! Both Dapr and your app logs will appear here.
 ```
 > **Note**: the `--app-port` (the port the app runs on) is configurable. Our Node app happens to run on port 3000, but we could configure it to run on any other port. Also note that the Dapr `--port` parameter is optional, and if not supplied, a random available port is used.
 
-The `dapr run` command looks for a `components` directory which holds yaml definition files for components Dapr will be using at runtime. When running locally, if the directory is not found it is created with yaml files which provide default definitions for a local development environment (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
+The `dapr run` command looks for a `~/.dapr/components` directory which holds yaml definition files for components Dapr will be using at runtime. When running locally, if the directory is not found it is created with yaml files which provide default definitions for a local development environment (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
 
 ```yml
 apiVersion: dapr.io/v1alpha1

--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -135,7 +135,7 @@ You're up and running! Both Dapr and your app logs will appear here.
 ```
 > **Note**: the `--app-port` (the port the app runs on) is configurable. Our Node app happens to run on port 3000, but we could configure it to run on any other port. Also note that the Dapr `--port` parameter is optional, and if not supplied, a random available port is used.
 
-The `dapr run` command looks for a `~/.dapr/components` directory which holds yaml definition files for components Dapr will be using at runtime. When running locally, if the directory is not found it is created with yaml files which provide default definitions for a local development environment (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
+The `dapr run` command looks for the default components directory under `~/.dapr/components` which holds yaml definition files for components Dapr will be using at runtime. When running locally, the yaml files which provide default definitions for a local development environment are placed in this default components directory (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
 
 ```yml
 apiVersion: dapr.io/v1alpha1

--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -135,7 +135,7 @@ You're up and running! Both Dapr and your app logs will appear here.
 ```
 > **Note**: the `--app-port` (the port the app runs on) is configurable. Our Node app happens to run on port 3000, but we could configure it to run on any other port. Also note that the Dapr `--port` parameter is optional, and if not supplied, a random available port is used.
 
-The `dapr run` command looks for the default components directory under `~/.dapr/components` which holds yaml definition files for components Dapr will be using at runtime. When running locally, the yaml files which provide default definitions for a local development environment are placed in this default components directory (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
+The `dapr run` command looks for the default components directory which for Linux/MacOS is `$HOME/.dapr/components` and for Windows is `%USERPROFILE%\.dapr\components` which holds yaml definition files for components Dapr will be using at runtime. When running locally, the yaml files which provide default definitions for a local development environment are placed in this default components directory (learn more about this flow [here](https://github.com/dapr/docs/blob/master/walkthroughs/darprun.md)). Review the `statestore.yaml` file in the `components` directory:
 
 ```yml
 apiVersion: dapr.io/v1alpha1

--- a/5.bindings/README.md
+++ b/5.bindings/README.md
@@ -53,7 +53,7 @@ Now that you have Kafka running locally on your machine, we'll need to run our m
 
 1. Navigate to Node subscriber directory in your CLI: `cd nodeapp`
 2. Install dependencies: `npm install`
-3. Run Node sample app with Dapr: `dapr run --app-id bindings-nodeapp --app-port 3000 node app.js`
+3. Run Node sample app with Dapr: `dapr run --app-id bindings-nodeapp --app-port 3000 node app.js --components-path ../components`
 
 ### Run Python Microservice with Output Binding
 
@@ -61,7 +61,7 @@ Next, we'll run the Python microservice that uses output bindings
 
 1. Open a new CLI window and navigate to Python subscriber directory in your CLI: `cd pythonapp`
 2. Install dependencies: `pip install requests`
-3. Run Python sample app with Dapr: `dapr run --app-id bindings-pythonapp python app.py`
+3. Run Python sample app with Dapr: `dapr run --app-id bindings-pythonapp python app.py --components-path ./components`
 
 ### Observe Logs
 

--- a/5.bindings/README.md
+++ b/5.bindings/README.md
@@ -53,7 +53,7 @@ Now that you have Kafka running locally on your machine, we'll need to run our m
 
 1. Navigate to Node subscriber directory in your CLI: `cd nodeapp`
 2. Install dependencies: `npm install`
-3. Run Node sample app with Dapr: `dapr run --app-id bindings-nodeapp --app-port 3000 node app.js --components-path ../components`
+3. Run Node sample app with Dapr: `dapr run --app-id bindings-nodeapp --app-port 3000 node app.js --components-path ./components`
 
 ### Run Python Microservice with Output Binding
 


### PR DESCRIPTION
# Description

Default components folder is now located in home dir and created at init time (https://github.com/dapr/cli/pull/354). Modify documentation accordingly


## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #227

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The sample code compiles correctly
* [ ] You've tested new builds of the sample if you changed sample code
* [* ] You've updated the sample's README if necessary
