### PR TITLE
Add private field to stop warning

### DIFF
--- a/1.hello-world/package.json
+++ b/1.hello-world/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node_server",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/10.hello-docker-compose/node/package.json
+++ b/10.hello-docker-compose/node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node_server",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/2.hello-kubernetes/node/package.json
+++ b/2.hello-kubernetes/node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node_server",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/3.distributed-calculator/node/package.json
+++ b/3.distributed-calculator/node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node-divide",
   "version": "0.0.1",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/4.pub-sub/node-subscriber/package.json
+++ b/4.pub-sub/node-subscriber/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node-subscriber",
   "version": "1.0.0",
+  "private": true,
   "description": "A subscriber microservice in the Dapr pub-sub sample",
   "main": "app.js",
   "scripts": {

--- a/4.pub-sub/react-form/package.json
+++ b/4.pub-sub/react-form/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-form",
   "version": "1.0.0",
+  "private": true,
   "description": "This project builds and serves the react form client along with the services that it depends on",
   "main": "server.js",
   "scripts": {

--- a/5.bindings/nodeapp/package.json
+++ b/5.bindings/nodeapp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node_server",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/7.middleware/echoapp/package.json
+++ b/7.middleware/echoapp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "echoapp",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/9.secretstore/node/package.json
+++ b/9.secretstore/node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node_server",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
# Description

Added private field to package.json files in all samples to stop npm from emitting the warning:

```bash
$ npm install
npm WARN node_server@1.0.0 No repository field.
```

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #196 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The sample code compiles correctly
* [ ] You've tested new builds of the sample if you changed sample code
* [ ] You've updated the sample's README if necessary
