### PR TITLE
modify k8s sample to expect injected env vars

### DIFF
--- a/2.hello-kubernetes/README.md
+++ b/2.hello-kubernetes/README.md
@@ -82,12 +82,15 @@ for /f "delims=" %a in ('kubectl get svc nodeapp --output 'jsonpath={.status.loa
 ```
 
 ## Step 4 - Verify Service call using external IP 
-Let's check if we are able to call the service using the external IP. From a command prompt run: 
+To call the service using the extracted external IP, from a command prompt run: 
 
 ```bash
 $ curl $NODE_APP/ports
 {"DAPR_HTTP_PORT":"3500","DAPR_GRPC_PORT":"50001"}
 ```
+
+> Note: This assumes that the external IP is available in the `NODE_APP` environment variable from the previous step.
+Minikube users cannot see the external IP. Instead, you can use `minikube service [service_name]` to access loadbalancer without external IP. Then export it to an environment variable.
 
 Here you can see that two ports are displayed. Both the ports have been injected when Dapr was enabled for this app. Additionally, in this sample the HTTP Port is used for further communication with the Dapr sidecar. 
 

--- a/2.hello-kubernetes/README.md
+++ b/2.hello-kubernetes/README.md
@@ -81,7 +81,17 @@ Windows
 for /f "delims=" %a in ('kubectl get svc nodeapp --output 'jsonpath={.status.loadBalancer.ingress[0].ip}') do @set NODE_APP=%a
 ```
 
-## Step 4 - Deploy the Python App with the Dapr Sidecar
+## Step 4 - Verify Service call using external IP 
+Let's check if we are able to call the service using the external IP. From a command prompt run: 
+
+```bash
+$ curl $NODE_APP/ports
+{"DAPR_HTTP_PORT":"3500","DAPR_GRPC_PORT":"50001"}
+```
+
+Here you can see that two ports are displayed. Both the ports have been injected when Dapr was enabled for this app. Additionally, in this sample the HTTP Port is used for further communication with the Dapr sidecar. 
+
+## Step 5 - Deploy the Python App with the Dapr Sidecar
 Next, let's take a quick look at our python app. Navigate to the python app in the kubernetes sample: `cd samples/2.hello-kubernetes/python` and open `app.py`.
 
 At a quick glance, this is a basic python app that posts JSON messages to `localhost:3500`, which is the default listening port for Dapr. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/invoke/nodeapp/method/neworder`. Our message contains some `data` with an orderId that increments once per second:
@@ -111,7 +121,7 @@ Now let's just wait for the pod to be in ```Running``` state:
 kubectl get pods --selector=app=python -w
 ```
 
-## Step 5 - Observe Messages
+## Step 6 - Observe Messages
 
 Now that we have our Node.js and python applications deployed, let's watch messages come through.
 
@@ -132,7 +142,7 @@ Got a new order! Order ID: 3
 Successfully persisted state
 ```
 
-## Step 6 - Confirm Successful Persistence
+## Step 7 - Confirm Successful Persistence
 
 Hit the Node.js app's order endpoint to get the latest order. Grab the external IP address that we saved before and, append "/order" and perform a GET request against it (enter it into your browser, use Postman, or curl it!):
 
@@ -143,7 +153,7 @@ curl $NODE_APP/order
 
 You should see the latest JSON in response!
 
-## Step 7 - Cleanup
+## Step 8 - Cleanup
 
 Once you're done using the sample, you can spin down your Kubernetes resources by navigating to the `./deploy` directory and running:
 

--- a/2.hello-kubernetes/node/app.js
+++ b/2.hello-kubernetes/node/app.js
@@ -10,7 +10,10 @@ require('isomorphic-fetch');
 const app = express();
 app.use(bodyParser.json());
 
-const daprPort = process.env.DAPR_HTTP_PORT || 3500;
+// These ports are injected automatically into the container.
+const daprPort = process.env.DAPR_HTTP_PORT; 
+const daprGRPCPort = process.env.DAPR_GRPC_PORT;
+
 const stateStoreName = `statestore`;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
 const port = 3000;
@@ -58,6 +61,12 @@ app.post('/neworder', (req, res) => {
         console.log(error);
         res.status(500).send({message: error});
     });
+});
+
+app.get('/ports', (_req, res) => {
+    console.log("DAPR_HTTP_PORT: " + daprPort);
+    console.log("DAPR_GRPC_PORT: " + daprGRPCPort);
+    res.status(200).send({DAPR_HTTP_PORT: daprPort, DAPR_GRPC_PORT: daprGRPCPort })
 });
 
 app.listen(port, () => console.log(`Node App listening on port ${port}!`));


### PR DESCRIPTION
# Description

Modify the hello-k8s sample to expect only injected env vars for Dapr ports. 

Added a simple step in the README to illustrate the same.

This is a **breaking change** to this sample.

Merge only after merging https://github.com/dapr/dapr/pull/1712

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/1637

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The sample code compiles correctly
* [x] You've tested new builds of the sample if you changed sample code
* [x] You've updated the sample's README if necessary
