### PR TITLE
Go templates for common Dapr callback pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,15 @@ Example:
 
 ## External samples
 
->This section will include external links to Dapr related samples, located outside the Dapr GitHub repositories.
+### Templates
+
+* [Dapr gRPC Service in Go](https://github.com/dapr/dapr-grpc-service-template) - Template project to jump start your Dapr event subscriber service with gRPC development
+* [Dapr HTTP Event Subscriber in Go](https://github.com/dapr/dapr-http-event-subscriber-template) - Template project to jump start your Dapr event subscriber service with HTTP development
+* [Dapr gRPC Event Subscriber in Go](https://github.com/dapr/dapr-grpc-event-subscriber-template) - Template project to jump start your Dapr event subscriber service with gRPC development
+* [dapr-http-cron-handler in Go](https://github.com/dapr/dapr-http-cron-handler-template) - Template project to jump start your Dapr service development for scheduled workloads
+
+
+
+
+
+


### PR DESCRIPTION
As templates, these need to be in their own repo. Adding them as external links even though they are in the dapr GitHub org