### PR TITLE
Updated link in Readme of hello-dapr-slim sample

### DIFF
--- a/hello-dapr-slim/README.md
+++ b/hello-dapr-slim/README.md
@@ -21,7 +21,7 @@ This sample requires you to have the following installed on your machine:
 
 ## Step 1 - Setup Dapr (Slim Init)
 
-Follow [instructions](https://docs.dapr.io/getting-started/install-dapr/#install-dapr-in-self-hosted-mode) to download and install the Dapr CLI and initialize Dapr.
+Follow [instructions](https://docs.dapr.io/operations/hosting/self-hosted/self-hosted-no-docker) to download and install the Dapr CLI and initialize Dapr.
 
 ## Step 2 - Understand the Code
 


### PR DESCRIPTION
Updated the instructions link under `Setup Dapr (Slim Init)` to point to the 'How-To: Run Dapr in self-hosted mode without Docker' article instead of the "How-To: Install Dapr into your local environment".  The self-hosted-no-docker article points to the original link as a prerequisite if the reader needs it. My fear was if they followed the directions on the original link it could be confusing because it requires docker and is not the slim init example.