### PR TITLE
Fix dapr command options

### DIFF
--- a/hello-dapr-slim/README.md
+++ b/hello-dapr-slim/README.md
@@ -80,17 +80,17 @@ First, POST the message by using Dapr cli in a new command line terminal:
 
 Windows Command Prompt
 ```sh
-dapr invoke --app-id nodeapp --method neworder --payload "{\"data\": { \"orderId\": \"41\" } }"
+dapr invoke --verb POST --app-id nodeapp --method neworder --data "{\"data\": { \"orderId\": \"41\" } }"
 ```
 
 Windows PowerShell
 ```sh
-dapr invoke --app-id nodeapp --method neworder --payload '{\"data\": { \"orderId\": \"41\" } }'
+dapr invoke --verb POST --app-id nodeapp --method neworder --data '{\"data\": { \"orderId\": \"41\" } }'
 ```
 
 Linux or MacOS
 ```sh
-dapr invoke --app-id nodeapp --method neworder --payload '{"data": { "orderId": "41" } }'
+dapr invoke --verb POST --app-id nodeapp --method neworder --data '{"data": { "orderId": "41" } }'
 ```
 
 Now, you can also do this using `curl` with:

--- a/hello-typescript/README.md
+++ b/hello-typescript/README.md
@@ -127,22 +127,22 @@ First, POST the message by using Dapr cli in a new command line terminal:
 
 Windows Command Prompt
 ```sh
-dapr invokePost --app-id nodeapp --method neworder --payload "{\"data\": { \"orderId\": \"41\" } }"
+dapr invoke --verb POST --app-id nodeapp --method neworder --data "{\"data\": { \"orderId\": \"41\" } }"
 ```
 
 Windows PowerShell
 ```sh
-dapr invokePost --app-id nodeapp --method neworder --payload '{\"data\": { \"orderId\": \"41\" } }'
+dapr invoke --verb POST --app-id nodeapp --method neworder --data '{\"data\": { \"orderId\": \"41\" } }'
 ```
 
 Linux or MacOS
 ```sh
-dapr invokePost --app-id nodeapp --method neworder --payload '{"data": { "orderId": "41" } }'
+dapr invoke --verb POST --app-id nodeapp --method neworder --data '{"data": { "orderId": "41" } }'
 ```
 
 Next, GET the content of the persisted order:
 ```sh
-dapr invokeGet --app-id nodeapp --method order
+dapr invoke --verb GET --app-id nodeapp --method order
 ```
 
 And the response should be:


### PR DESCRIPTION
This PR includes changing example command of `dapr` CLI in README.md because there is no sub-command `invokeGet`, `invokePost` and option `--payload` in `dapr` CLI 1.0.0.

![image](https://user-images.githubusercontent.com/4566555/108804845-c3eb4800-75e1-11eb-8362-94e3cda41231.png)

