### PR TITLE
Remove Lombok

### DIFF
--- a/twitter-sentiment-processor/demos/javademo/processor/pom.xml
+++ b/twitter-sentiment-processor/demos/javademo/processor/pom.xml
@@ -93,10 +93,6 @@
             <artifactId>jackson-module-parameter-names</artifactId>
             <version>2.11.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/ApplicationController.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/ApplicationController.java
@@ -30,20 +30,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.dapr.apps.twitter.processor.model.Sentiment;
 import io.dapr.apps.twitter.processor.model.Text;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @RestController
-@Slf4j
-@RequiredArgsConstructor
 public class ApplicationController {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ApplicationController.class);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     private static final String PATH = "/text/analytics/v3.0/sentiment";
+
+    public ApplicationController(String endpoint, String subscriptionKey) {
+      this.endpoint = endpoint;
+      this.subscriptionKey = subscriptionKey;
+    }
 
     @Autowired
     @Qualifier("endpoint")

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/DaprConfig.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/DaprConfig.java
@@ -15,11 +15,11 @@ import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.GetSecretRequest;
 import io.dapr.client.domain.GetSecretRequestBuilder;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Configuration
 public class DaprConfig {
+
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DaprConfig.class);
 
   private static final String SECRET_STORE =
     Optional.ofNullable(System.getenv("SECRET_STORE")).orElse("secretstore");

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/DaprConfig.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/DaprConfig.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.GetSecretRequest;
 import io.dapr.client.domain.GetSecretRequestBuilder;
 
 @Configuration

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Sentiment.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Sentiment.java
@@ -6,23 +6,36 @@ package io.dapr.apps.twitter.processor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-
-@Data
-@FieldDefaults(level = AccessLevel.PRIVATE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class Sentiment {
 
     @JsonProperty("sentiment")
-    String sentiment;
+    private String sentiment;
 
     @JsonProperty("confidence")
-    float confidence;
+    private float confidence;
+
+    public Sentiment() {
+    }
+
+    public Sentiment(String sentiment, float confidence) {
+        this.sentiment = sentiment;
+        this.confidence = confidence;
+    }
+
+    public String getSentiment() {
+        return sentiment;
+    }
+
+    public void setSentiment(String sentiment) {
+        this.sentiment = sentiment;
+    }
+
+    public float getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(float confidence) {
+        this.confidence = confidence;
+    }
+
 }

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Sentiment.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Sentiment.java
@@ -38,4 +38,9 @@ public class Sentiment {
         this.confidence = confidence;
     }
 
+    @Override
+    public String toString() {
+        return "Sentiment [confidence=" + confidence + ", sentiment=" + sentiment + "]";
+    }
+
 }

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Text.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Text.java
@@ -6,23 +6,29 @@ package io.dapr.apps.twitter.processor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-
-@Data
-@FieldDefaults(level = AccessLevel.PRIVATE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class Text {
 
     @JsonProperty("text")
-    String text;
+    private String text;
 
     @JsonProperty("lang")
-    String language;
+    private String language;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+
 }

--- a/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Text.java
+++ b/twitter-sentiment-processor/demos/javademo/processor/src/main/java/io/dapr/apps/twitter/processor/model/Text.java
@@ -30,5 +30,10 @@ public class Text {
         this.language = language;
     }
 
+    @Override
+    public String toString() {
+        return "Text [language=" + language + ", text=" + text + "]";
+    }
+
 
 }

--- a/twitter-sentiment-processor/demos/javademo/provider/pom.xml
+++ b/twitter-sentiment-processor/demos/javademo/provider/pom.xml
@@ -88,10 +88,6 @@
             <artifactId>jackson-module-parameter-names</artifactId>
             <version>2.11.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/DaprConfig.java
+++ b/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/DaprConfig.java
@@ -10,11 +10,12 @@ import org.springframework.context.annotation.Configuration;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
+
 @Configuration
 public class DaprConfig {
+
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DaprConfig.class);
 
   private static final DaprClientBuilder BUILDER = new DaprClientBuilder();
 

--- a/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/AnalyzedTweet.java
+++ b/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/AnalyzedTweet.java
@@ -4,30 +4,55 @@
  */
 package io.dapr.apps.twitter.provider.model;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-
-@Data
-@FieldDefaults(level = AccessLevel.PRIVATE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class AnalyzedTweet {
 
+    public AnalyzedTweet() {
+    }
+
+    public AnalyzedTweet(Tweet tweet, Sentiment sentiment) {
+        setId(tweet.getId());
+        setSentiment(sentiment);
+        setTweet(tweet);
+    }
+
     @JsonProperty("id")
-    String id;
+    private String id;
 
     @JsonProperty("tweet")
-    Tweet tweet;
+    private Tweet tweet;
 
     @JsonProperty("sentiment")
-    Sentiment sentiment;
+    private Sentiment sentiment;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Tweet getTweet() {
+        return tweet;
+    }
+
+    public void setTweet(Tweet tweet) {
+        this.tweet = tweet;
+    }
+
+    public Sentiment getSentiment() {
+        return sentiment;
+    }
+
+    public void setSentiment(Sentiment sentiment) {
+        this.sentiment = sentiment;
+    }
+
+    @Override
+    public String toString() {
+        return "AnalyzedTweet [id=" + id + ", sentiment=" + sentiment + ", tweet=" + tweet + "]";
+    }
+
 }

--- a/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/Sentiment.java
+++ b/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/Sentiment.java
@@ -6,23 +6,33 @@ package io.dapr.apps.twitter.provider.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-
-@Data
-@FieldDefaults(level = AccessLevel.PRIVATE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class Sentiment {
 
     @JsonProperty("sentiment")
-    String sentiment;
+    private String sentiment;
 
     @JsonProperty("confidence")
-    float confidence;
+    private float confidence;
+
+    public String getSentiment() {
+        return sentiment;
+    }
+
+    public void setSentiment(String sentiment) {
+        this.sentiment = sentiment;
+    }
+
+    public float getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(float confidence) {
+        this.confidence = confidence;
+    }
+
+    @Override
+    public String toString() {
+        return "Sentiment [confidence=" + confidence + ", sentiment=" + sentiment + "]";
+    }
+
 }

--- a/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/Tweet.java
+++ b/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/Tweet.java
@@ -6,32 +6,67 @@ package io.dapr.apps.twitter.provider.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-
-@Data
-@FieldDefaults(level = AccessLevel.PRIVATE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class Tweet {
 
     @JsonProperty("id_str")
-    String id;
+    private String id;
 
     @JsonProperty("user")
-    TwitterUser author;
+    private TwitterUser author;
 
     @JsonProperty("full_text")
-    String fullText;
+    private String fullText;
 
     @JsonProperty("text")
-    String text;
+    private String text;
 
     @JsonProperty("lang")
-    String language;
+    private String language;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public TwitterUser getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(TwitterUser author) {
+        this.author = author;
+    }
+
+    public String getFullText() {
+        return fullText;
+    }
+
+    public void setFullText(String fullText) {
+        this.fullText = fullText;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    @Override
+    public String toString() {
+        return "Tweet [author=" + author + ", fullText=" + fullText + ", id=" + id + ", language=" + language
+                + ", text=" + text + "]";
+    }
+
 }

--- a/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/TwitterUser.java
+++ b/twitter-sentiment-processor/demos/javademo/provider/src/main/java/io/dapr/apps/twitter/provider/model/TwitterUser.java
@@ -6,26 +6,44 @@ package io.dapr.apps.twitter.provider.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-
-@Data
-@FieldDefaults(level = AccessLevel.PRIVATE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class TwitterUser {
 
     @JsonProperty("name")
-    String name;
+    private String name;
 
     @JsonProperty("screen_name")
-    String screenName;
+    private String screenName;
 
     @JsonProperty("profile_image_url_https")
-    String picture;
+    private String picture;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getScreenName() {
+        return screenName;
+    }
+
+    public void setScreenName(String screenName) {
+        this.screenName = screenName;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+
+    public void setPicture(String picture) {
+        this.picture = picture;
+    }
+
+    @Override
+    public String toString() {
+        return "TwitterUser [name=" + name + ", picture=" + picture + ", screenName=" + screenName + "]";
+    }
+
 }

--- a/twitter-sentiment-processor/demos/javademo/viewer/pom.xml
+++ b/twitter-sentiment-processor/demos/javademo/viewer/pom.xml
@@ -92,10 +92,6 @@
             <artifactId>jackson-module-parameter-names</artifactId>
             <version>2.11.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/twitter-sentiment-processor/demos/javademo/viewer/src/main/java/io/dapr/apps/twitter/viewer/ApplicationController.java
+++ b/twitter-sentiment-processor/demos/javademo/viewer/src/main/java/io/dapr/apps/twitter/viewer/ApplicationController.java
@@ -17,14 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.dapr.Topic;
 import io.dapr.client.domain.CloudEvent;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
-@Slf4j
-@RequiredArgsConstructor
 @RestController
 public class ApplicationController {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ApplicationController.class);
 
     private static final String PUBSUB = "messagebus";
   

--- a/twitter-sentiment-processor/demos/javademo/viewer/src/main/java/io/dapr/apps/twitter/viewer/SocketTextHandler.java
+++ b/twitter-sentiment-processor/demos/javademo/viewer/src/main/java/io/dapr/apps/twitter/viewer/SocketTextHandler.java
@@ -12,10 +12,9 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public class SocketTextHandler extends TextWebSocketHandler {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SocketTextHandler.class);
 
     @Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {

--- a/twitter-sentiment-processor/demos/javademo/viewer/src/main/java/io/dapr/apps/twitter/viewer/WebSocketPubSub.java
+++ b/twitter-sentiment-processor/demos/javademo/viewer/src/main/java/io/dapr/apps/twitter/viewer/WebSocketPubSub.java
@@ -13,10 +13,9 @@ import java.util.Map;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public class WebSocketPubSub {
+
+	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(WebSocketPubSub.class);
 
 	private final Map<String, WebSocketSession> sessions = Collections.synchronizedMap(new HashMap<>());
 


### PR DESCRIPTION
Lombok adds complexity to the build process and tooling support. It has become a bad practice adding Lombok to projects, and an impediment to the modernization of Java code to later versions of Java.