### PR TITLE
Fixing a broken script in the dapr-apim-integration README

### DIFF
--- a/dapr-apim-integration/README.md
+++ b/dapr-apim-integration/README.md
@@ -339,7 +339,7 @@ And install Redis and wait for the deployment to complete:
 ```shell
 helm install redis bitnami/redis  
 kubectl rollout status statefulset.apps/redis-master
-kubectl rollout status statefulset.apps/redis-slave
+kubectl rollout status statefulset.apps/redis-replicas
 ```
 
 ### Dapr Components 


### PR DESCRIPTION
Bitnami has updated their Redis Helm chart naming to remove slave wording. This change has broken one of the scripts in the dapr-apim-integration README. I've fixed this script to reflect the new naming.