### PR TITLE
Adding pubsub sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are new to Dapr, you may want to review following resources first:
 | [Dapr integration in Azure APIM](./dapr-apim-integration) | Dapr configuration in Azure API Management service using self-hosted gateway on Kubernetes. Illustrates exposing Dapr API for service method invocation, publishing content to a Pub/Sub topic, and binding invocation with request content transformation. |
 | [Distributed Calendar](./dapr-distributed-calendar) | Shows use of statestore, pubsub and output binding features of Dapr to roughly create a distributed version of a MVCS architecture application. |
 | [Hello Service Fabric](./hello-service-fabric) | Shows use of statestore, pubsub and service invocation in a Service Fabric environment running the Dapr sidecar as a guest executable. |
+| [Pub-sub routing](./pub-sub-routing) | Demonstrates how to use Dapr to enable pub-sub applications with message routing.  |
 
 ## External samples
 

--- a/pub-sub-routing/.gitignore
+++ b/pub-sub-routing/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/pub-sub-routing/Dockerfile
+++ b/pub-sub-routing/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8-alpine
+WORKDIR /usr/src/app
+COPY . .
+RUN npm install
+EXPOSE 3000
+CMD [ "node", "app.js" ]

--- a/pub-sub-routing/README.md
+++ b/pub-sub-routing/README.md
@@ -1,0 +1,100 @@
+# Dapr Pub-Sub routing
+
+In this quickstart, you'll run a subscriber application that makes use of Pub-Sub routing. The application can be quickly changed to:
+
+* Toggle between programmatic and declarative subscriptions (or use both as long as there is no overlap)
+* Add other routing rules with different [CEL](https://github.com/google/cel-spec) expressions
+* Enable/disable routing (disable `PubSub.Routing` in `config.yaml`)
+
+> **Note**: Because this example is intended to be something to play around with, it makes use of the `in-memory` pubsub component and is not intended to be deployed to Kubernetes.
+
+**Install dependencies**
+
+<!-- STEP
+name: Install node dependencies
+working_dir: .
+-->
+
+```bash
+npm install
+```
+
+<!-- END_STEP -->
+
+**Run the application**
+
+<!-- STEP
+name: Run node subscriber
+expected_stdout_lines:
+  - "WIDGET:"
+  - "GADGET:"
+  - "PRODUCT (default):"
+expected_stderr_lines:
+output_match_mode: substring
+working_dir: .
+background: true
+sleep: 5
+-->
+
+```bash
+dapr run --app-id pubsub-routing --config config.yaml --components-path ./components --app-port 3000 node app.js
+```
+
+<!-- END_STEP -->
+
+**Switch between programmatic and declarative subscriptions**
+
+In `app.js`, the handler for `/dapr/subscribe` returns the programmatic subscriptions. The contents are commented out to demonstrate usage of a declarative subscription in `components/subscription.yaml`.
+
+You can switch from declarative to programmatic subscriptions by:
+
+1) Changing `kind: Subscription` to `kind: Subscription_disabled` in `components/subscription.yaml` so that `daprd` does not load the file
+2) Uncommenting the JSON response for `/dapr/subscribe` in `app.js`
+3) Stop (CTRL-C) and restart the application using the `dapr run` command above
+
+**Publish messages to route**
+
+Try the following `curl` commands in a separate terminal.
+
+Publish a widget
+
+<!-- STEP
+name: Curl publish message
+expected_stdout_lines:
+  - "OK"
+  - "OK"
+  - "OK"
+expected_stderr_lines:
+-->
+
+```bash
+curl -s http://localhost:3000/publish -H Content-Type:application/json --data @messages/widget.json
+```
+
+Publish a gadget
+
+```bash
+curl -s http://localhost:3000/publish -H Content-Type:application/json --data @messages/gadget.json
+```
+
+Publish a thingamajig
+
+```bash
+curl -s http://localhost:3000/publish -H Content-Type:application/json --data @messages/thingamajig.json
+```
+
+<!-- END_STEP -->
+
+<!-- STEP
+expected_stdout_lines: 
+  - 'app stopped successfully: pubsub-routing'
+expected_stderr_lines:
+output_match_mode: substring
+name: Shutdown dapr
+-->
+
+```bash
+dapr stop --app-id pubsub-routing
+```
+
+<!-- END_STEP -->

--- a/pub-sub-routing/app.js
+++ b/pub-sub-routing/app.js
@@ -1,0 +1,90 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+const daprPort = process.env.DAPR_HTTP_PORT || "3500";
+
+// The Dapr endpoint for the state store component to store the tweets.
+const pubsubEndpoint = `http://localhost:${daprPort}/v1.0/publish/pubsub/inventory`;
+
+const express = require('express');
+const axios = require('axios');
+
+const app = express();
+// Dapr publishes messages with the application/cloudevents+json content-type
+app.use(express.json({ type: ['application/json', 'application/*+json'] }));
+
+const port = 3000;
+
+app.get('/dapr/subscribe', (_req, res) => {
+  // Programmatic subscriptions
+  // See ./components/subscription.yaml for declarative subscription.
+  //
+  res.json([
+    // Previous subscription structure.
+    // {
+    //   pubsubname: "pubsub",
+    //   topic: "inventory",
+    //   route: "products"
+    // }
+    //
+    // Subscription with routing rules and default route.
+    // {
+    //   pubsubname: "pubsub",
+    //   topic: "inventory",
+    //   routes: {
+    //     rules: [
+    //       {
+    //         match: `event.type == "widget"`,
+    //         path: "widgets"
+    //       },
+    //       {
+    //         match: `event.type == "gadget"`,
+    //         path: "gadgets"
+    //       }
+    //     ],
+    //     default: "products"
+    //   }
+    // }
+  ]);
+});
+
+// Default product handler.
+app.post('/products', (req, res) => {
+  console.log("🤔 PRODUCT (default): ", req.body);
+  console.log();
+  res.sendStatus(200);
+});
+
+// Specific handler for widgets.
+app.post('/widgets', (req, res) => {
+  console.log("🪛  WIDGET: ", req.body);
+  console.log();
+  res.sendStatus(200);
+});
+
+// Specific handler for gadgets.
+app.post('/gadgets', (req, res) => {
+  console.log("📱 GADGET: ", req.body);
+  console.log();
+  res.sendStatus(200);
+});
+
+// Allow publishing freeform cloud events to the topic.
+app.post('/publish', async (req, res) => {
+  console.log("publishing", req.body);
+  console.log();
+  axios.post(pubsubEndpoint, req.body, {
+    headers: {
+      'content-type': 'application/cloudevents+json'
+    }
+  })
+    .then(() => { res.sendStatus(200); })
+    .catch(error => {
+      res.sendStatus(500);
+      console.error('There was an error!', error);
+    });
+});
+
+app.listen(port, () => console.log(`Node App listening on port ${port}!`));

--- a/pub-sub-routing/components/in-memory.yaml
+++ b/pub-sub-routing/components/in-memory.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+  namespace: default
+spec:
+  type: pubsub.in-memory
+  version: v1

--- a/pub-sub-routing/components/subscription.yaml
+++ b/pub-sub-routing/components/subscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysubscriptions
+  namespace: default
+spec:
+  pubsubname: pubsub
+  topic: inventory
+  routes:
+    rules:
+      - match: "event.type == 'widget'"
+        path: widgets
+      - match: "event.type == 'gadget'"
+        path: gadgets
+    default: products

--- a/pub-sub-routing/config.yaml
+++ b/pub-sub-routing/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: pubsubroutingconfig
+spec:
+  features:
+    - name: PubSub.Routing
+      enabled: true

--- a/pub-sub-routing/messages/gadget.json
+++ b/pub-sub-routing/messages/gadget.json
@@ -1,0 +1,9 @@
+{
+  "type": "gadget",
+  "source": "routing-demo", 
+  "data": {
+    "description": "Hello, Gadget!",
+    "price": 75.00,
+    "gadgetField": "gadgets only"
+  }
+}

--- a/pub-sub-routing/messages/thingamajig.json
+++ b/pub-sub-routing/messages/thingamajig.json
@@ -1,0 +1,8 @@
+{
+  "type": "thingamajig",
+  "source": "routing-demo", 
+  "data": {
+      "description": "Hello, Thingamajig!",
+      "price": 5.00
+  }
+}

--- a/pub-sub-routing/messages/widget.json
+++ b/pub-sub-routing/messages/widget.json
@@ -1,0 +1,9 @@
+{
+  "type": "widget",
+  "source": "routing-demo", 
+  "data": {
+    "description": "Hello, Widget!",
+    "price": 25.00,
+    "widgetField": "widgets only"
+  }
+}

--- a/pub-sub-routing/package.json
+++ b/pub-sub-routing/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node-pubsub-routing",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A routing subscriber sample",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Phil Kedy",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.21.4",
+    "express": "^4.17.1"
+  }
+}


### PR DESCRIPTION
# Description

Adding the sample that was demoed in the [9/21/2021 community call](https://www.youtube.com/watch?v=QqJgRmbH82I&t=1063s). Will also link to this sample from [the howto](https://docs.dapr.io/developing-applications/building-blocks/pubsub/howto-route-messages/).