### PR TITLE
Update k8s registry reference

### DIFF
--- a/read-kubernetes-events/README.md
+++ b/read-kubernetes-events/README.md
@@ -135,7 +135,7 @@ kubectl create ns kube-events
 * Deploy a quick Kubernetes hello-world application in the created namespace:
 
 ```bash
-kubectl create deployment hello-node -n kube-events --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment hello-node -n kube-events --image=registry.k8s.io/echoserver:1.4
 ```
 
 Output logs from the node application should be of the form:


### PR DESCRIPTION
## What's this PR for?

For #142 

## What's new in this PR?

Per https://github.com/kubernetes/k8s.io/issues/4780, Kubernetes is migrating its image registry to registry.k8s.io, and this repository is impacted.

This PR update the references of k8s.gcr.io to registry.k8s.io.