### PR TITLE
wasm: update config to use `url` instead of `path`

### DIFF
--- a/hello-wasm/components/wasm.yaml
+++ b/hello-wasm/components/wasm.yaml
@@ -6,5 +6,5 @@ spec:
   type: middleware.http.wasm
   version: v1
   metadata:
-  - name: path
-    value: "./wasm/main.wasm"
+  - name: url
+    value: "file://wasm/main.wasm"


### PR DESCRIPTION
https://github.com/dapr/components-contrib/pull/2817/ updated `middleware/http/wasm` to use `url` instead of `path` for config, but the example was left out. This PR fixes the example so that it runs as expected.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
