### PR TITLE
Typo fix for dapr runtime version in wasm doc

### DIFF
--- a/hello-wasm/README.md
+++ b/hello-wasm/README.md
@@ -4,7 +4,7 @@
 
 | Attribute            | Details |
 |----------------------|---------|
-| Dapr runtime version | v0.10   |
+| Dapr runtime version | v1.10   |
 | Language             | TinyGo  | 
 | Environment          | Local   |
 


### PR DESCRIPTION
The Wasm HTTP middleware is added since [v1.10](https://v1-10.docs.dapr.io/reference/components-reference/supported-middleware/middleware-wasm/). Fix the runtime version in the doc. 