### PR TITLE
Add link to readme for a Java Sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you are new to Dapr, you may want to review following resources first:
 | [Dapr RetroPOS](https://github.com/robece/dapr-retropos) | Dapr Retro Point of Sales is a sample of backend workflow based on microservices. |
 | [Dapr Traffic Control](https://github.com/edwinvw/dapr-traffic-control) | Simulated traffic-control system with speeding cameras. This sample features all the Dapr building-blocks. This is also the sample application used in the book [Dapr for .NET Developers](https://docs.microsoft.com/en-us/dotnet/architecture/dapr-for-net-developers/). |
 | [Dapr Examples](https://github.com/mstrYoda/dapr-examples) | Example usage of Dapr in Golang. This repository contains examples about to use of state store, access management, pubsub and subscription.|
+| [Java Pub/Sub Sample](https://github.com/Azure-Samples/pubsub-dapr-aks-java/tree/main) | Demonstrate a pub/sub messaging architecture using Dapr for a Java application running in a Kubernetes cluster. |
 
 ## Sample maintenance
 


### PR DESCRIPTION
Added a link to a "Java Pub/Sub Sample using Kubernetes and DAPR" from the Azure-Samples org.

Fixes #149