### PR TITLE
Adding eShopOnDapr to external projects in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you are new to Dapr, you may want to review following resources first:
 | [Dapr Traffic Control](https://github.com/edwinvw/dapr-traffic-control) | Simulated traffic-control system with speeding cameras. This sample features all the Dapr building-blocks. This is also the sample application used in the book [Dapr for .NET Developers](https://docs.microsoft.com/en-us/dotnet/architecture/dapr-for-net-developers/). |
 | [Dapr Examples](https://github.com/mstrYoda/dapr-examples) | Example usage of Dapr in Golang. This repository contains examples about to use of state store, access management, pubsub and subscription.|
 | [Java Pub/Sub Sample](https://github.com/Azure-Samples/pubsub-dapr-aks-java/tree/main) | Demonstrate a pub/sub messaging architecture using Dapr for a Java application running in a Kubernetes cluster. |
+| [eShop on Dapr](https://github.com/dotnet-architecture/eShopOnDapr) | A sample .NET Core E-Commerce application based on [eShopOnContainers](https://github.com/dotnet-architecture/eShopOnContainers), powered by Dapr. |
 
 ## Sample maintenance
 


### PR DESCRIPTION
Adding external project [eShopOnDapr](https://github.com/dotnet-architecture/eShopOnDapr) to external projects in README.md file, as requested in issue #60 