### PR TITLE
Update Python Workflow sample to dapr-ext-workflow v0.3.0

### DIFF
--- a/workflow-orderprocessing-python/README.md
+++ b/workflow-orderprocessing-python/README.md
@@ -5,7 +5,7 @@
 | Attribute | Details |
 |--------|--------|
 | Dapr runtime version | 1.12.0 |
-| Dapr Workflow Python SDK | v0.2.0 |
+| Dapr Workflow Python SDK | v0.3.0 |
 | Language | Python |
 | Environment | Local |
 
@@ -251,4 +251,3 @@ If you want to exercise the error handling path of the workflow, you can put the
 1. You can also see the failed workflow in Zipkin, which should look something like this:
 
    ![Zipkin UI for failure](./zipkin-workflow-failure.png)
-    

--- a/workflow-orderprocessing-python/demo.http
+++ b/workflow-orderprocessing-python/demo.http
@@ -18,11 +18,11 @@ Content-Type: application/json
 
 
 ### Get the status of an order
-GET http://localhost:3000/orders/order_casey_6glku
+GET http://localhost:3000/orders/xxx
 
 
 ### Approve an order
-POST http://localhost:3000/orders/order_riley_xcgyz/approve
+POST http://localhost:3000/orders/xxx/approve
 Content-Type: application/json
 
 {"approver": "Chris", "approved": true}

--- a/workflow-orderprocessing-python/services/orderprocessing/requirements.txt
+++ b/workflow-orderprocessing-python/services/orderprocessing/requirements.txt
@@ -1,2 +1,2 @@
-dapr-ext-workflow >= 0.2.0
+dapr-ext-workflow >= 0.3.0
 flask >= 3.0.0


### PR DESCRIPTION
This PR updates the [workflow-orderprocessing-python](https://github.com/dapr/samples/tree/master/workflow-orderprocessing-python) sample to use the latest version of the Workflow SDK, v0.3.0.

This SDK update fixes the error handling path of the workflow, which would correctly notify that an error occurred when submitting an order to a deactivated shipping service but would fail to actually invoke the `refund_payment` activity or send a notification about the refunded payment. The root issue was a bug in the Durable Task Python SDK, which has since been fixed.

With this PR to update the SDK version, the failure handling part of the demo now works 100% correctly.

![image](https://github.com/dapr/samples/assets/2704139/f33f8f36-ccf4-436b-ac35-1c95e3c0152c)
